### PR TITLE
Optimize memory

### DIFF
--- a/vendor/github.com/go-openapi/validate/object_validator.go
+++ b/vendor/github.com/go-openapi/validate/object_validator.go
@@ -143,14 +143,16 @@ func (o *objectValidator) validatePatternProperty(key string, value interface{},
 	succeededOnce := false
 	var patterns []string
 
-	for k, schema := range o.PatternProperties {
-		if match, _ := regexp.MatchString(k, key); match {
-			patterns = append(patterns, k)
-			matched = true
-			validator := NewSchemaValidator(&schema, o.Root, o.Path+"."+key, o.KnownFormats)
+	if len(o.PatternProperties) != 0 {
+		for k, schema := range o.PatternProperties {
+			if match, _ := regexp.MatchString(k, key); match {
+				patterns = append(patterns, k)
+				matched = true
+				validator := NewSchemaValidator(&schema, o.Root, o.Path+"."+key, o.KnownFormats)
 
-			res := validator.Validate(value)
-			result.Merge(res)
+				res := validator.Validate(value)
+				result.Merge(res)
+			}
 		}
 	}
 

--- a/vendor/github.com/go-openapi/validate/schema_props.go
+++ b/vendor/github.com/go-openapi/validate/schema_props.go
@@ -45,16 +45,24 @@ func (s *schemaPropsValidator) SetPath(path string) {
 
 func newSchemaPropsValidator(path string, in string, allOf, oneOf, anyOf []spec.Schema, not *spec.Schema, deps spec.Dependencies, root interface{}, formats strfmt.Registry) *schemaPropsValidator {
 	var anyValidators []SchemaValidator
-	for _, v := range anyOf {
-		anyValidators = append(anyValidators, *NewSchemaValidator(&v, root, path, formats))
+	if len(anyOf) != 0 {
+		for _, v := range anyOf {
+			anyValidators = append(anyValidators, *NewSchemaValidator(&v, root, path, formats))
+		}
 	}
+
 	var allValidators []SchemaValidator
-	for _, v := range allOf {
-		allValidators = append(allValidators, *NewSchemaValidator(&v, root, path, formats))
+	if len(allOf) != 0 {
+		for _, v := range allOf {
+			allValidators = append(allValidators, *NewSchemaValidator(&v, root, path, formats))
+		}
 	}
+
 	var oneValidators []SchemaValidator
-	for _, v := range oneOf {
-		oneValidators = append(oneValidators, *NewSchemaValidator(&v, root, path, formats))
+	if len(oneOf) != 0 {
+		for _, v := range oneOf {
+			oneValidators = append(oneValidators, *NewSchemaValidator(&v, root, path, formats))
+		}
 	}
 
 	var notValidator *SchemaValidator


### PR DESCRIPTION
The for-range clause is evaluated once before the beginning of each loop. This causes additional unwanted memory allocation (when the length of the map is zero). Adding an if clause avoids this additional allocation.

More notes here: https://github.com/nikhita/go-openapi-validate-benchmark/blob/master/results/memory-optimization.md.